### PR TITLE
add a new reminder

### DIFF
--- a/dialogue.py
+++ b/dialogue.py
@@ -147,6 +147,29 @@ SCHEDULED = [
         ],
     },
     {
+        "cron": "30 7 * * 1",
+        "sequences": [
+            [
+                {
+                    "icon_emoji": ":celeste-mom-normal00:",
+                    "username": "Mum",
+                    "messages": [
+                        "Dillan, be sure to ask your friends a question to _make some new pals_!",
+                    ],
+                }
+            ],
+            [
+                {
+                    "icon_emoji": ":celeste-mom-normal01:",
+                    "username": "Mum",
+                    "messages": [
+                        "Dillan, do you know what time it is? It's *question-asking time*!",
+                    ],
+                }
+            ],
+        ],
+    },
+    {
         "cron": "30 21 * * *",
         "sequences": [
             [


### PR DESCRIPTION
adds a reminder to ask a question on mondays

i will never do this again, writing dialogue sucks, enjoy :D

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new reminder to prompt users to ask a question every Monday morning, enhancing user engagement.

New Features:
- Introduce a new reminder feature that sends a message every Monday at 7:30 AM to prompt users to ask a question and engage with friends.

<!-- Generated by sourcery-ai[bot]: end summary -->